### PR TITLE
Add embulk-output-s3_parquet plugin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3033,6 +3033,29 @@
                 </td>
                 <td>Dumps records to Pixela.</td>
               </tr>
+
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/civitaspo/embulk-output-s3_parquet" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/civitaspo/embulk-output-s3_parquet/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/civitaspo/embulk-output-s3_parquet/stargazers">s3_parquet</a>
+                  <pre class="install">$ embulk gem install embulk-output-s3_parquet</pre>
+                </td>
+                <td style="min-width:13em">
+                  <a href="https://github.com/civitaspo">Civitaspo
+                  <img src="https://avatars0.githubusercontent.com/u/4525500?v=4" height=32 width=32></img></a>
+                </td>
+                <td>Embulk (https://github.com/embulk/embulk/) output plugin to dump records as Apache Parquet (https://parquet.apache.org/) files on S3.</td>
+              </tr>
               
             </tbody>
           </table>


### PR DESCRIPTION
* I created embulk-output-s3_parquet plugin that dumps data as parquet file into S3.
    * https://github.com/civitaspo/plugins.embulk.org/pull/new/add-output-s3_parquet
    * twitter (Japanese) https://twitter.com/Civitaspo/status/1087639428355354624