### PR TITLE
Add a link to embulk-input-sendgrid

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1659,6 +1659,29 @@
                 <td>Loads records from Google Cloud Firestore</td>
               </tr>
 
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/kaacun/embulk-input-sendgrid" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/kaacun/embulk-input-sendgrid/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/kaacun/embulk-input-sendgrid">sendgrid</a>
+                  <pre class="install">$ embulk gem install embulk-input-sendgrid</pre>
+                </td>
+                <td style="min-width:13em">
+
+                  kaacun
+
+                </td>
+                <td>Loads records from Sendgrid</td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
I've created a new input plugin
https://github.com/kaacun/embulk-input-sendgrid