### PR TITLE
Add a link to embulk-input-cloudwatch_logs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1682,6 +1682,30 @@
                 </td>
                 <td>Loads records from Sendgrid</td>
               </tr>
+
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/cosmo0920/embulk-input-cloudwatch_logs" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/cosmo0920/embulk-input-cloudwatch_logs/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/cosmo0920/embulk-input-cloudwatch_logs">cloudwatch_logs</a>
+                  <pre class="install">$ embulk gem install embulk-input-cloudwatch_logs</pre>
+                </td>
+                <td style="min-width:13em">
+
+                  Hiroshi Hatake
+
+                </td>
+                <td>Loads records from Cloudwatch Logs.</td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
I'd created a new input plugin. ;)
https://github.com/cosmo0920/embulk-input-cloudwatch_logs