### PR TITLE
Add a link to embulk-filter-convert_unicode_sequence_to_string

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4650,6 +4650,30 @@
                 </td>
                 <td>Affix</td>
               </tr>
+
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/reizist/embulk-filter-convert_unicode_sequence_to_string" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/reizist/embulk-filter-convert_unicode_sequence_to_string/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/reizist/embulk-filter-convert_unicode_sequence_to_string">convert_unicode_sequence_to_string</a>
+                  <pre class="install">$ embulk gem install embulk-filter-convert_unicode_sequence_to_string</pre>
+                </td>
+                <td style="min-width:13em">
+
+                  reizist
+
+                </td>
+                <td>Convert unicode sequence to string.</td>
+              </tr>
               
             </tbody>
           </table>


### PR DESCRIPTION
I created an filter plugin: convert_unicode_sequence_to_string
See https://github.com/reizist/embulk-filter-convert_unicode_sequence_to_string