### PR TITLE
Add a link to embulk-input-zendesk_guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1732,6 +1732,31 @@
                 <td>An input plugin for Embulk (https://github.com/embulk/embulk/) that unions all data loaded by your defined embulk input & filters plugin configuration.</td>
               </tr>
 
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/syou6162/embulk-input-zendesk_guide" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/syou6162/embulk-input-zendesk_guide/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/syou6162/embulk-input-zendesk_guide">zendesk_guide</a>
+                  <pre class="install">$ embulk gem install embulk-input-zendesk_guide</pre>
+                </td>
+                <td style="min-width:13em">
+
+                  <a href="https://github.com/syou6162">syou6162
+                  <img src="https://avatars0.githubusercontent.com/u/18356?v=4" height=32 width=32></img></a>
+
+                </td>
+                <td>Loads records from Zendesk Guide.</td>
+              </tr>
+
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
I've created a new input plugin!

- https://github.com/syou6162/embulk-input-zendesk_guide