### PR TITLE
Add a link to embulk-parser-variable_length_bytes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5610,6 +5610,31 @@
                 <td>Parses Mahout files read by other file input plugins.</td>
               </tr>
               
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/koji-m/embulk-parser-variable_length_bytes" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/koji-m/embulk-parser-variable_length_bytes/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/koji-m/embulk-parser-variable_length_bytes">variable_length_bytes</a>
+                  <pre class="install">$ embulk gem install embulk-parser-variable_length_bytes</pre>
+                </td>
+                <td style="min-width:13em">
+                  
+                  <a href="https://github.com/koji-m">Koji Matsumoto
+                  <img src="https://avatars0.githubusercontent.com/u/7721142?v=4" height=32 width=32></img></a>
+                  
+                </td>
+                <td>Parses variable length bytes files read by other file input plugins.</td>
+              </tr>
+
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
I've created a new parser plugin.
- https://github.com/koji-m/embulk-parser-variable_length_bytes