### PR TITLE
Add embulk-output-http_json

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3323,7 +3323,30 @@
                 </td>
                 <td>Embulk (https://github.com/embulk/embulk/) output plugin to dump records to Apache Kafka (https://kafka.apache.org/).</td>
               </tr>
-              
+
+              <tr>
+                <td style="width:80px">
+                  <div class="github-btn-container">
+                    <span class="github-btn" class="github-stargazers">
+                      <a class="gh-btn" href="https://github.com/trocco-io/embulk-output-http_json" target="_blank">
+                        <span class="gh-ico"></span>
+                        <span class="gh-text">Star</span>
+                      </a>
+                      <a class="gh-count" href="https://github.com/trocco-io/embulk-output-http_json/stargazers" target="_blank" style="display: block">-</a>
+                    </span>
+                  </div>
+                </td>
+                <td style="min-width:9em">
+                  <a href="https://github.com/trocco-io/embulk-output-http_json">spanner</a>
+                  <pre class="install">$ embulk gem install embulk-output-http_json</pre>
+                </td>
+                <td style="min-width:13em">
+                  <a href="https://github.com/civitaspo">Civitaspo
+                  <img src="https://avatars0.githubusercontent.com/u/4525500?v=4" height=32 width=32></img></a>
+                </td>
+                <td>Egest records as json via http.</td>
+              </tr>
+
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
- Add embulk-output-http_json
  - https://github.com/trocco-io/embulk-output-http_json
  - An embulk output plugin to egest records as json via http.
  - This plugin is probably the first case of using [embulk/embulk-base-restclient](https://github.com/embulk/embulk-base-restclient).