### PR TITLE
Change plugin name of "embulk-ouptut-http_json" from "spanner" to "http_json"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3337,7 +3337,7 @@
                   </div>
                 </td>
                 <td style="min-width:9em">
-                  <a href="https://github.com/trocco-io/embulk-output-http_json">spanner</a>
+                  <a href="https://github.com/trocco-io/embulk-output-http_json">http_json</a>
                   <pre class="install">$ embulk gem install embulk-output-http_json</pre>
                 </td>
                 <td style="min-width:13em">


### PR DESCRIPTION
Follow up for https://github.com/embulk/plugins.embulk.org/pull/19
Plugin name of embulk-output-http_json would be "http_json"
<img width="1199" alt="146309158-83a7f497-b70e-4373-be84-6123d0355b35" src="https://user-images.githubusercontent.com/155269/147227599-ff484529-5889-444d-86c8-02a51066e7d2.png">

I didn't notice before merging PR :)